### PR TITLE
reducing the chance of flaky test failure

### DIFF
--- a/src/test/java/me/escoffier/vertx/completablefuture/VertxCompletableFutureTest.java
+++ b/src/test/java/me/escoffier/vertx/completablefuture/VertxCompletableFutureTest.java
@@ -877,7 +877,7 @@ public class VertxCompletableFutureTest {
     success.complete(1);
 
     VertxCompletableFuture<Integer> success2 = new VertxCompletableFuture<>(vertx);
-    vertx.setTimer(100, l -> success2.complete(42));
+    vertx.setTimer(500, l -> success2.complete(42));
 
 
     VertxCompletableFuture<Integer> failure = new VertxCompletableFuture<>(vertx);


### PR DESCRIPTION
**Description:**
This test is flakily fails. I run this test many times and it makes assertion fails. The failure message is as follows.

**Failure:**
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.392 sec <<< FAILURE!
testAcceptEither(me.escoffier.vertx.completablefuture.VertxCompletableFutureTest)  Time elapsed: 0.357 sec  <<< FAILURE!
java.lang.AssertionError: Not equals : 42 != 1
	at io.vertx.ext.unit.impl.TestContextImpl.reportAssertionError(TestContextImpl.java:362)
	at io.vertx.ext.unit.impl.TestContextImpl.assertEquals(TestContextImpl.java:258)
	at io.vertx.ext.unit.impl.TestContextImpl.assertEquals(TestContextImpl.java:245)
	at me.escoffier.vertx.completablefuture.VertxCompletableFutureTest.lambda$null$102(VertxCompletableFutureTest.java:902)
	at java.util.concurrent.CompletableFuture.orAccept(CompletableFuture.java:1455)
	at java.util.concurrent.CompletableFuture.orAcceptStage(CompletableFuture.java:1470)
	at java.util.concurrent.CompletableFuture.acceptEither(CompletableFuture.java:2105)
	at me.escoffier.vertx.completablefuture.VertxCompletableFuture.acceptEither(VertxCompletableFuture.java:771)
	at me.escoffier.vertx.completablefuture.VertxCompletableFutureTest.lambda$testAcceptEither$106(VertxCompletableFutureTest.java:898)
	at io.vertx.core.impl.ContextImpl.executeTask(ContextImpl.java:320)
	at io.vertx.core.impl.EventLoopContext.lambda$executeAsync$0(EventLoopContext.java:38)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:404)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:495)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:905)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.lang.Thread.run(Thread.java:750)

Results :
Failed tests:   testAcceptEither(me.escoffier.vertx.completablefuture.VertxCompletableFutureTest): Not equals : 42 != 1
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0